### PR TITLE
Loosen conditional experimental speed threshold

### DIFF
--- a/frogpilot/controls/lib/conditional_experimental_mode.py
+++ b/frogpilot/controls/lib/conditional_experimental_mode.py
@@ -94,7 +94,7 @@ class ConditionalExperimentalMode:
     if frogpilot_toggles.csc_curves:
       curve_ctrl_active = (
         self.frogpilot_planner.frogpilot_vcruise.csc_controlling_speed
-        and self.frogpilot_planner.frogpilot_vcruise.csc_target < v_ego * 0.9
+        and self.frogpilot_planner.frogpilot_vcruise.csc_target < v_ego
       )
       if curve_ctrl_active:
         self.status_value = 8


### PR DESCRIPTION
## Summary
- trigger conditional experimental mode when curve speed controller target falls below current speed
- revert formatting changes to conditional_experimental_mode

## Testing
- `poetry run pre-commit run --files frogpilot/controls/lib/conditional_experimental_mode.py` *(fails: Command '['/root/.pyenv/shims/python', '-EsSc', 'import sys; print(sys.executable)']' returned non-zero exit status 127)*

------
https://chatgpt.com/codex/tasks/task_b_689de799468883209cfa2c5c0349141c