### PR TITLE
Add configurable stopping error factor

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -539,6 +539,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"StopAccelStock", PERSISTENT},
     {"StoppingDecelRate", PERSISTENT},
     {"StoppingDecelRateStock", PERSISTENT},
+    {"StoppingErrorFactor", PERSISTENT},
     {"StoppedTimer", PERSISTENT},
     {"TacoTune", PERSISTENT},
     {"TacoTuneHacks", PERSISTENT},

--- a/frogpilot/common/frogpilot_variables.py
+++ b/frogpilot/common/frogpilot_variables.py
@@ -412,6 +412,7 @@ frogpilot_default_params: list[tuple[str, str | bytes, int, str]] = [
   ("StopAccelStock", "", 3, ""),
   ("StoppingDecelRate", "", 3, ""),
   ("StoppingDecelRateStock", "", 3, ""),
+  ("StoppingErrorFactor", "2.0", 3, "2.0"),
   ("StoppedTimer", "0", 1, "0"),
   ("TacoTune", "0", 2, "0"),
   ("TacoTuneHacks", "0", 2, "0"),
@@ -573,6 +574,7 @@ class FrogPilotVariables:
     pcm_cruise = CP.pcmCruise
     startAccel = CP.startAccel
     stopAccel = CP.stopAccel
+    stoppingErrorFactor = 2.0
     steerActuatorDelay = CP.steerActuatorDelay
     steerKp = FPCP.lateralTuning.torque.kp
     steerRatio = CP.steerRatio
@@ -621,6 +623,7 @@ class FrogPilotVariables:
     toggle.stoppingDecelRate = np.clip(params.get_float("StoppingDecelRate"), 0.001, 1) if advanced_longitudinal_tuning and tuning_level >= level["StoppingDecelRate"] else toggle.stoppingDecelRate
     toggle.vEgoStarting = np.clip(params.get_float("VEgoStarting"), 0.01, 1) if advanced_longitudinal_tuning and tuning_level >= level["VEgoStarting"] else toggle.vEgoStarting
     toggle.vEgoStopping = np.clip(params.get_float("VEgoStopping"), 0.01, 1) if advanced_longitudinal_tuning and tuning_level >= level["VEgoStopping"] else toggle.vEgoStopping
+    toggle.stoppingErrorFactor = np.clip(params.get_float("StoppingErrorFactor"), 0.5, 5) if advanced_longitudinal_tuning and tuning_level >= level["StoppingErrorFactor"] else stoppingErrorFactor
 
     toggle.alert_volume_controller = params.get_bool("AlertVolumeControl") if tuning_level >= level["AlertVolumeControl"] else default.get_bool("AlertVolumeControl")
     toggle.disengage_volume = params.get_int("DisengageVolume") if toggle.alert_volume_controller and tuning_level >= level["DisengageVolume"] else default.get_int("DisengageVolume")

--- a/frogpilot/ui/qt/offroad/frogpilot_settings.cc
+++ b/frogpilot/ui/qt/offroad/frogpilot_settings.cc
@@ -234,6 +234,11 @@ void FrogPilotSettingsWindow::updateVariables() {
     stoppingDecelRate = CP.getStoppingDecelRate();
     vEgoStarting = CP.getVEgoStarting();
     vEgoStopping = CP.getVEgoStopping();
+    stoppingErrorFactor = params.getFloat("StoppingErrorFactor");
+    if (stoppingErrorFactor == 0) {
+      stoppingErrorFactor = 2.0;
+      params.putFloat("StoppingErrorFactor", stoppingErrorFactor);
+    }
 
     float currentDelayStock = params.getFloat("SteerDelayStock");
     float currentFrictionStock = params.getFloat("SteerFrictionStock");

--- a/frogpilot/ui/qt/offroad/frogpilot_settings.h
+++ b/frogpilot/ui/qt/offroad/frogpilot_settings.h
@@ -44,6 +44,7 @@ public:
   float steerRatio;
   float stopAccel;
   float stoppingDecelRate;
+  float stoppingErrorFactor;
   float vEgoStarting;
   float vEgoStopping;
 

--- a/frogpilot/ui/qt/offroad/longitudinal_settings.cc
+++ b/frogpilot/ui/qt/offroad/longitudinal_settings.cc
@@ -10,6 +10,8 @@ FrogPilotLongitudinalPanel::FrogPilotLongitudinalPanel(FrogPilotSettingsWindow *
 
   longitudinalLayout->addWidget(longitudinalPanel);
 
+  stoppingErrorFactor = 2.0;
+
   FrogPilotListWidget *advancedLongitudinalTuneList = new FrogPilotListWidget(this);
   FrogPilotListWidget *aggressivePersonalityList = new FrogPilotListWidget(this);
   FrogPilotListWidget *conditionalExperimentalList = new FrogPilotListWidget(this);
@@ -62,6 +64,7 @@ FrogPilotLongitudinalPanel::FrogPilotLongitudinalPanel(FrogPilotSettingsWindow *
     {"VEgoStarting", vEgoStarting != 0 ? QString(tr("Start Speed (Default: %1)")).arg(QString::number(vEgoStarting, 'f', 2)) : tr("Start Speed"), tr("Speed where openpilot begins to exit the stopped state. Higher values avoid creeping but may feel sluggish; lower values move sooner but risk creeping."), ""},
     {"StopAccel", stopAccel != 0 ? QString(tr("Stop Acceleration (Default: %1)")).arg(QString::number(stopAccel, 'f', 2)) : tr("Stop Acceleration"), tr("Brake force applied to hold the vehicle still. Larger values prevent creeping on hills but might jerk to a stop. Smaller values can feel smoother but may allow rolling."), ""},
     {"StoppingDecelRate", stoppingDecelRate != 0 ? QString(tr("Stopping Rate (Default: %1)")).arg(QString::number(stoppingDecelRate, 'f', 2)) : tr("Stopping Rate"), tr("How quickly braking ramps up when stopping. Faster rates shorten stopping distance but can be harsh; slower rates are smoother but need more room."), ""},
+    {"StoppingErrorFactor", QString(tr("Stopping Error Factor (Default: %1)")).arg(QString::number(stoppingErrorFactor, 'f', 1)), tr("Adjustment factor for braking correction when stopping. Higher values apply stronger corrections; lower values soften them."), ""},
     {"VEgoStopping", vEgoStopping != 0 ? QString(tr("Stop Speed (Default: %1)")).arg(QString::number(vEgoStopping, 'f', 2)) : tr("Stop Speed"), tr("Speed where openpilot beings to enter the stopped state. Higher values brake earlier for smoother stops but might stop too soon; lower values wait longer and can overshoot."), ""},
 
     {"ConditionalExperimental", tr("Conditional Experimental Mode"), tr("Automatically switch to <b>Experimental Mode</b> when set conditions are met."), "../../frogpilot/assets/toggle_icons/icon_conditional.png"},
@@ -187,6 +190,9 @@ FrogPilotLongitudinalPanel::FrogPilotLongitudinalPanel(FrogPilotSettingsWindow *
     } else if (param == "StoppingDecelRate") {
       stoppingDecelRateToggle = new FrogPilotParamValueControl(param, title, desc, icon, 0.001, 1, tr(" m/s²"), std::map<float, QString>(), 0.001, true);
       longitudinalToggle = stoppingDecelRateToggle;
+    } else if (param == "StoppingErrorFactor") {
+      stoppingErrorFactorToggle = new FrogPilotParamValueControl(param, title, desc, icon, 0.5, 5, "", std::map<float, QString>(), 0.1, true);
+      longitudinalToggle = stoppingErrorFactorToggle;
     } else if (param == "VEgoStopping") {
       vEgoStoppingToggle = new FrogPilotParamValueControl(param, title, desc, icon, 0.01, 1, tr(" m/s²"), std::map<float, QString>(), 0.01);
       longitudinalToggle = vEgoStoppingToggle;
@@ -654,6 +660,7 @@ void FrogPilotLongitudinalPanel::showEvent(QShowEvent *event) {
   startAccel = parent->startAccel;
   stopAccel = parent->stopAccel;
   stoppingDecelRate = parent->stoppingDecelRate;
+  stoppingErrorFactor = parent->stoppingErrorFactor;
   tuningLevel = parent->tuningLevel;
   vEgoStarting = parent->vEgoStarting;
   vEgoStopping = parent->vEgoStopping;
@@ -665,6 +672,7 @@ void FrogPilotLongitudinalPanel::showEvent(QShowEvent *event) {
   startAccelToggle->setTitle(QString(tr("Start Acceleration (Default: %1)")).arg(QString::number(startAccel, 'f', 2)));
   stopAccelToggle->setTitle(QString(tr("Stop Acceleration (Default: %1)")).arg(QString::number(stopAccel, 'f', 2)));
   stoppingDecelRateToggle->setTitle(QString(tr("Stopping Rate (Default: %1)")).arg(QString::number(stoppingDecelRate, 'f', 2)));
+  stoppingErrorFactorToggle->setTitle(QString(tr("Stopping Error Factor (Default: %1)")).arg(QString::number(stoppingErrorFactor, 'f', 1)));
   vEgoStartingToggle->setTitle(QString(tr("Start Speed (Default: %1)")).arg(QString::number(vEgoStarting, 'f', 2)));
   vEgoStoppingToggle->setTitle(QString(tr("Stop Speed (Default: %1)")).arg(QString::number(vEgoStopping, 'f', 2)));
 
@@ -839,7 +847,7 @@ void FrogPilotLongitudinalPanel::updateToggles() {
       setVisible &= !(params.getBool("LongitudinalTune") && params.getBool("HumanAcceleration"));
     }
 
-    else if (key == "StoppingDecelRate" || key == "VEgoStarting" || key == "VEgoStopping") {
+    else if (key == "StoppingDecelRate" || key == "StoppingErrorFactor" || key == "VEgoStarting" || key == "VEgoStopping") {
       setVisible &= !isGM || !params.getBool("ExperimentalGMTune");
       setVisible &= !isToyota || !params.getBool("FrogsGoMoosTweak");
     }

--- a/frogpilot/ui/qt/offroad/longitudinal_settings.h
+++ b/frogpilot/ui/qt/offroad/longitudinal_settings.h
@@ -36,12 +36,13 @@ private:
   float startAccel;
   float stopAccel;
   float stoppingDecelRate;
+  float stoppingErrorFactor;
   float vEgoStarting;
   float vEgoStopping;
 
   std::map<QString, AbstractControl*> toggles;
 
-  std::set<QString> advancedLongitudinalTuneKeys = {"LongitudinalActuatorDelay", "StartAccel", "StopAccel", "StoppingDecelRate", "VEgoStarting", "VEgoStopping"};
+  std::set<QString> advancedLongitudinalTuneKeys = {"LongitudinalActuatorDelay", "StartAccel", "StopAccel", "StoppingDecelRate", "StoppingErrorFactor", "VEgoStarting", "VEgoStopping"};
   std::set<QString> aggressivePersonalityKeys = {"AggressiveFollow", "AggressiveJerkAcceleration", "AggressiveJerkDeceleration", "AggressiveJerkDanger", "AggressiveJerkSpeed", "AggressiveJerkSpeedDecrease", "ResetAggressivePersonality"};
   std::set<QString> conditionalExperimentalKeys = {"CESpeed", "CESpeedLead", "CECurves", "CECscCurves", "CELead", "CEModelStopTime", "CENavigation", "CESignalSpeed", "ShowCEMStatus"};
   std::set<QString> curveSpeedKeys = {"CalibratedLateralAcceleration", "CalibrationProgress", "ResetCurveData", "ShowCSCStatus"};
@@ -62,6 +63,7 @@ private:
   FrogPilotParamValueControl *startAccelToggle;
   FrogPilotParamValueControl *stopAccelToggle;
   FrogPilotParamValueControl *stoppingDecelRateToggle;
+  FrogPilotParamValueControl *stoppingErrorFactorToggle;
   FrogPilotParamValueControl *vEgoStartingToggle;
   FrogPilotParamValueControl *vEgoStoppingToggle;
 

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -170,7 +170,7 @@ class LongControl:
 
       if CS.aEgo > max_expected_accel or CS.vEgo < 0.5 and CS.aEgo < min_expected_accel:
         release_step = interp(CS.vEgo, stopping_v_bp, stopping_v)
-        error_factor = 0.12 if CS.aEgo > min_expected_accel else 2.
+        error_factor = 0.12 if CS.aEgo > min_expected_accel else frogpilot_toggles.stoppingErrorFactor
         error = max_expected_accel - ((min_expected_accel - max_expected_accel) * error_factor) - CS.aEgo
         step_factor = release_step if CS.aEgo < max_expected_accel or CS.aEgo > 0. else 0.1
         output_accel += error * step_factor * DT_CTRL


### PR DESCRIPTION
## Summary
- make stopping error factor adjustable (0.5–5) with default 2
- expose new Stopping Error Factor control in advanced longitudinal tuning settings
- hook longcontrol to use user-selected stopping error factor

## Testing
- `pre-commit run --all-files` *(fails: Schema validation errors in GitHub workflows)*
- `python -m pytest selfdrive/controls/lib/tests` *(fails: ModuleNotFoundError: No module named 'openpilot.common.params_pyx')*


------
https://chatgpt.com/codex/tasks/task_b_689f02a7dad0832084b75833e3d464ec