### PR TITLE
feat: allow half-step increased stopped distance

### DIFF
--- a/frogpilot/common/frogpilot_variables.py
+++ b/frogpilot/common/frogpilot_variables.py
@@ -254,7 +254,7 @@ frogpilot_default_params: list[tuple[str, str | bytes, int, str]] = [
   ("HumanFollowing", "1", 2, "0"),
   ("ShortDistanceFactor", "1.0", 2, "0"),
   ("LongDistanceFactor", "1.0", 2, "0"),
-  ("IncreasedStoppedDistance", "0", 1, "0"),
+  ("IncreasedStoppedDistance", "0.0", 1, "0"),
   ("IncreaseThermalLimits", "0", 2, "0"),
   ("IsLdwEnabled", "0", 0, "0"),
   ("IsMetric", "0", 0, "0"),
@@ -913,7 +913,11 @@ class FrogPilotVariables:
     toggle.cruise_increase_long = params.get_int("CustomCruiseLong") if quality_of_life_longitudinal and not pcm_cruise and tuning_level >= level["CustomCruiseLong"] else default.get_int("CustomCruiseLong")
     toggle.force_standstill = quality_of_life_longitudinal and (params.get_bool("ForceStandstill") if tuning_level >= level["ForceStandstill"] else default.get_bool("ForceStandstill"))
     toggle.force_stops = quality_of_life_longitudinal and (params.get_bool("ForceStops") if tuning_level >= level["ForceStops"] else default.get_bool("ForceStops"))
-    toggle.increased_stopped_distance = params.get_int("IncreasedStoppedDistance") * distance_conversion if quality_of_life_longitudinal and tuning_level >= level["IncreasedStoppedDistance"] else default.get_int("IncreasedStoppedDistance") * CV.FOOT_TO_METER
+    toggle.increased_stopped_distance = (
+      params.get_float("IncreasedStoppedDistance") * distance_conversion
+      if quality_of_life_longitudinal and tuning_level >= level["IncreasedStoppedDistance"]
+      else default.get_float("IncreasedStoppedDistance") * CV.FOOT_TO_METER
+    )
     map_gears = quality_of_life_longitudinal and (params.get_bool("MapGears") if tuning_level >= level["MapGears"] else default.get_bool("MapGears"))
     toggle.map_acceleration = map_gears and (params.get_bool("MapAcceleration") if tuning_level >= level["MapAcceleration"] else default.get_bool("MapAcceleration"))
     toggle.map_deceleration = map_gears and (params.get_bool("MapDeceleration") if tuning_level >= level["MapDeceleration"] else default.get_bool("MapDeceleration"))

--- a/frogpilot/ui/qt/offroad/longitudinal_settings.cc
+++ b/frogpilot/ui/qt/offroad/longitudinal_settings.cc
@@ -362,7 +362,7 @@ FrogPilotLongitudinalPanel::FrogPilotLongitudinalPanel(FrogPilotSettingsWindow *
     } else if (param == "CustomCruiseLong") {
       longitudinalToggle = new FrogPilotParamValueControl(param, title, desc, icon, 1, 99, tr(" mph"));
     } else if (param == "IncreasedStoppedDistance") {
-      longitudinalToggle = new FrogPilotParamValueControl(param, title, desc, icon, 0, 10, tr(" feet"));
+      longitudinalToggle = new FrogPilotParamValueControl(param, title, desc, icon, 0, 10, tr(" feet"), std::map<float, QString>(), 0.5);
     } else if (param == "MapGears") {
       std::vector<QString> mapGearsToggles{"MapAcceleration", "MapDeceleration"};
       std::vector<QString> mapGearsToggleNames{tr("Acceleration"), tr("Deceleration")};
@@ -685,7 +685,7 @@ void FrogPilotLongitudinalPanel::updateMetric(bool metric, bool bootRun) {
     double distanceConversion = metric ? FOOT_TO_METER : METER_TO_FOOT;
     double speedConversion = metric ? MILE_TO_KM : KM_TO_MILE;
 
-    params.putIntNonBlocking("IncreasedStoppedDistance", params.getInt("IncreasedStoppedDistance") * distanceConversion);
+    params.putFloatNonBlocking("IncreasedStoppedDistance", params.getFloat("IncreasedStoppedDistance") * distanceConversion);
 
     params.putIntNonBlocking("CESignalSpeed", params.getInt("CESignalSpeed") * speedConversion);
     params.putIntNonBlocking("CESpeed", params.getInt("CESpeed") * speedConversion);
@@ -710,16 +710,16 @@ void FrogPilotLongitudinalPanel::updateMetric(bool metric, bool bootRun) {
 
   static bool labelsInitialized = false;
   if (!labelsInitialized) {
-    for (int i = 0; i <= 10; ++i) {
-      imperialDistanceLabels[i] = i == 0 ? tr("Off") : i == 1 ? QString::number(i) + tr(" foot") : QString::number(i) + tr(" feet");
+    for (float i = 0.0f; i <= 10.0f; i += 0.5f) {
+      imperialDistanceLabels[i] = i == 0.0f ? tr("Off") : i == 1.0f ? QString::number(i) + tr(" foot") : QString::number(i) + tr(" feet");
     }
 
     for (int i = 0; i <= 99; ++i) {
       imperialSpeedLabels[i] = i == 0 ? tr("Off") : QString::number(i) + tr(" mph");
     }
 
-    for (int i = 0; i <= 3; ++i) {
-      metricDistanceLabels[i] = i == 0 ? tr("Off") : i == 1 ? QString::number(i) + tr(" meter") : QString::number(i) + tr(" meters");
+    for (float i = 0.0f; i <= 3.0f; i += 0.5f) {
+      metricDistanceLabels[i] = i == 0.0f ? tr("Off") : i == 1.0f ? QString::number(i) + tr(" meter") : QString::number(i) + tr(" meters");
     }
 
     for (int i = 0; i <= 150; ++i) {


### PR DESCRIPTION
## Summary
- allow setting IncreasedStoppedDistance in 0.5 increments
- store and convert increased stop distance as float for metric/imperial

## Testing
- `pre-commit run --files frogpilot/ui/qt/offroad/longitudinal_settings.cc frogpilot/common/frogpilot_variables.py` *(fails: cpplint errors in existing file)*
- `PYENV_VERSION=3.11.12 pytest frogpilot` *(fails: ModuleNotFoundError: openpilot.common.params_pyx)*

------
https://chatgpt.com/codex/tasks/task_b_68a862c9093483209e5b03e85280af5a