### PR TITLE
Simplify human lane change surrogate handling

### DIFF
--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -3,7 +3,7 @@ import importlib
 import math
 from collections import deque
 from types import SimpleNamespace
-from typing import Any, Tuple
+from typing import Any
 
 import capnp
 from cereal import messaging, log, car, custom
@@ -30,11 +30,6 @@ V_EGO_STATIONARY = 4.   # no stationary object flag below this speed
 RADAR_TO_CENTER = 2.7   # (deprecated) RADAR is ~ 2.7m ahead from center of car
 RADAR_TO_CAMERA = 1.52  # RADAR is ~ 1.5m ahead from center of mesh frame
 
-ADJACENT_CONFIRM_FRAMES = 3
-ADJACENT_RELEASE_FRAMES = 2
-ADJACENT_CONFIRM_MIN_DREL = 8.0
-ADJACENT_CONFIRM_MAX_SPEED_DIFF = 15.0
-ADJACENT_PROBABILITY_MULTIPLIER = 1.2
 SURROGATE_DREL_OFFSET = 40.0
 SURROGATE_VLEAD_DELTA = 5.0
 
@@ -168,40 +163,13 @@ def laplacian_pdf(x: float, mu: float, b: float):
 
 
 def match_vision_to_track(v_ego: float, lead: capnp._DynamicStructReader, model_data: capnp._DynamicStructReader,
-                          tracks: dict[int, Track], preferred_track_id: int | None = None,
-                          human_lane_changes_enabled: bool = False):
+                          tracks: dict[int, Track]):
   offset_vision_dist = lead.x[0] - RADAR_TO_CAMERA
 
   def track_is_sane(track: Track):
     dist_sane = abs(track.dRel - offset_vision_dist) < max([(offset_vision_dist) * .25, 5.0])
     vel_sane = (abs(track.vRel + v_ego - lead.v[0]) < 10) or (v_ego + track.vRel > 3)
     return dist_sane and vel_sane
-
-  if human_lane_changes_enabled and preferred_track_id is not None and preferred_track_id in tracks:
-    preferred_track = tracks[preferred_track_id]
-    if track_is_sane(preferred_track):
-      return preferred_track
-
-  if model_data.meta.laneChangeState == LaneChangeState.laneChangeStarting:
-    direction = model_data.meta.laneChangeDirection
-
-    if direction == LaneChangeDirection.left:
-      left_tracks = [track for track in tracks.values() if track.leadLeft]
-      if left_tracks:
-        if human_lane_changes_enabled and preferred_track_id is not None:
-          preferred_track = tracks.get(preferred_track_id)
-          if preferred_track in left_tracks and track_is_sane(preferred_track):
-            return preferred_track
-        return min(left_tracks, key=lambda c: c.dRel)
-
-    elif direction == LaneChangeDirection.right:
-      right_tracks = [track for track in tracks.values() if track.leadRight]
-      if right_tracks:
-        if human_lane_changes_enabled and preferred_track_id is not None:
-          preferred_track = tracks.get(preferred_track_id)
-          if preferred_track in right_tracks and track_is_sane(preferred_track):
-            return preferred_track
-        return min(right_tracks, key=lambda c: c.dRel)
 
   def prob(c):
     prob_d = laplacian_pdf(c.dRel, offset_vision_dist, lead.xStd[0])
@@ -241,12 +209,11 @@ def get_RadarState_from_vision(lead_msg: capnp._DynamicStructReader, v_ego: floa
 
 def get_lead(v_ego: float, ready: bool, tracks: dict[int, Track], lead_msg: capnp._DynamicStructReader,
              model_v_ego: float, model_data: capnp._DynamicStructReader, standstill: bool,
-             frogpilot_plan: capnp._DynamicStructReader, frogpilot_toggles: SimpleNamespace, 
-             low_speed_override: bool = True, preferred_track_id: int | None = None,
-             human_lane_changes_enabled: bool = False) -> dict[str, Any]:
+             frogpilot_plan: capnp._DynamicStructReader, frogpilot_toggles: SimpleNamespace,
+             low_speed_override: bool = True) -> dict[str, Any]:
   # Determine leads, this is where the essential logic happens
   if len(tracks) > 0 and ready and lead_msg.prob > frogpilot_toggles.lead_detection_probability:
-    track = match_vision_to_track(v_ego, lead_msg, model_data, tracks, preferred_track_id, human_lane_changes_enabled)
+    track = match_vision_to_track(v_ego, lead_msg, model_data, tracks)
   else:
     track = None
 
@@ -312,14 +279,54 @@ class RadarD:
 
     self.frogpilot_toggles = get_frogpilot_toggles()
 
-    self.adjacent_override_track_id: int | None = None
-    self.adjacent_candidate_track_id: int | None = None
-    self.adjacent_candidate_frames = 0
-    self.adjacent_release_frames = 0
-
-    self.current_lead_track_id: int | None = None
-    self.lane_change_initial_lead_id: int | None = None
+    self.surrogate_track_ids: set[int] = set()
+    self.main_untracked_active = False
+    self.main_untracked_sign = 0
+    self.surrogate_untracked_side_signs: set[int] = set()
     self.prev_lane_change_state = LaneChangeState.off
+
+  def _reset_lane_change_surrogates(self):
+    self.surrogate_track_ids.clear()
+    self.main_untracked_active = False
+    self.main_untracked_sign = 0
+    self.surrogate_untracked_side_signs.clear()
+
+  def _update_lane_change_surrogates(self, sm: messaging.SubMaster, lead: dict[str, Any]):
+    lane_change_state = sm['modelV2'].meta.laneChangeState
+
+    if not (self.frogpilot_toggles.human_lane_changes and self.ready):
+      self._reset_lane_change_surrogates()
+      self.prev_lane_change_state = lane_change_state
+      return
+
+    active_states = (LaneChangeState.laneChangeStarting, LaneChangeState.laneChangeFinishing)
+
+    if lane_change_state in active_states:
+      if self.prev_lane_change_state not in active_states:
+        self._reset_lane_change_surrogates()
+        if lead.get('status', False):
+          track_id = lead.get('radarTrackId', -1)
+          if track_id >= 0:
+            self.surrogate_track_ids.add(track_id)
+          else:
+            self.main_untracked_active = True
+            self.main_untracked_sign = self._lead_side_sign(lead)
+        else:
+          self.main_untracked_active = True
+          self.main_untracked_sign = 0
+    else:
+      self._reset_lane_change_surrogates()
+
+    self.prev_lane_change_state = lane_change_state
+
+  @staticmethod
+  def _lead_side_sign(lead: dict[str, Any]) -> int:
+    y_rel = lead.get('yRel', 0.0)
+    if y_rel > 0.5:
+      return 1
+    if y_rel < -0.5:
+      return -1
+    return 0
 
   def _apply_overtake_surrogate(self, lead: dict[str, Any], sm: messaging.SubMaster) -> dict[str, Any]:
     if not lead.get('status', False):
@@ -329,17 +336,46 @@ class RadarD:
       return lead
 
     lane_change_state = sm['modelV2'].meta.laneChangeState
-    if lane_change_state not in (LaneChangeState.preLaneChange, LaneChangeState.laneChangeStarting, LaneChangeState.laneChangeFinishing):
+    if lane_change_state not in (LaneChangeState.laneChangeStarting, LaneChangeState.laneChangeFinishing):
       return lead
 
     lane_change_direction = sm['modelV2'].meta.laneChangeDirection
-    if lane_change_direction not in (LaneChangeDirection.left, LaneChangeDirection.right):
-      return lead
 
     lead_track_id = lead.get('radarTrackId', -1)
+    side_sign = self._lead_side_sign(lead)
 
-    if self.adjacent_override_track_id is not None and lead_track_id == self.adjacent_override_track_id:
+    apply_surrogate = False
+
+    if lead_track_id >= 0 and lead_track_id in self.surrogate_track_ids:
+      apply_surrogate = True
+    elif lead_track_id < 0:
+      if self.main_untracked_active and (
+        (self.main_untracked_sign == 0 and side_sign == 0) or
+        side_sign == self.main_untracked_sign
+      ):
+        apply_surrogate = True
+      elif side_sign in self.surrogate_untracked_side_signs:
+        apply_surrogate = True
+    elif lane_change_direction == LaneChangeDirection.left:
+      if lead.get('yRel', 0.0) > 0:
+        apply_surrogate = True
+    elif lane_change_direction == LaneChangeDirection.right:
+      if lead.get('yRel', 0.0) < 0:
+        apply_surrogate = True
+
+    if not apply_surrogate:
       return lead
+
+    if lead_track_id >= 0:
+      self.surrogate_track_ids.add(lead_track_id)
+    else:
+      if not self.main_untracked_active:
+        self.main_untracked_active = True
+        self.main_untracked_sign = side_sign
+      elif self.main_untracked_sign == 0 and side_sign != 0:
+        self.surrogate_untracked_side_signs.add(side_sign)
+      elif self.main_untracked_sign != 0 and side_sign not in (0, self.main_untracked_sign):
+        self.surrogate_untracked_side_signs.add(side_sign)
 
     v_lead = lead.get('vLead', self.v_ego)
 
@@ -354,135 +390,6 @@ class RadarD:
     new_lead['modelProb'] = max(new_lead.get('modelProb', 0.0), 0.01)
 
     return new_lead
-
-  def _valid_adjacent_candidate(self, adjacent_lead: dict[str, Any], lane_width: float) -> bool:
-    if not adjacent_lead.get('status', False):
-      return False
-
-    if adjacent_lead.get('radarTrackId', -1) < 0:
-      return False
-
-    if adjacent_lead.get('dRel', 0.0) < ADJACENT_CONFIRM_MIN_DREL:
-      return False
-
-    if abs(adjacent_lead.get('vLead', self.v_ego) - self.v_ego) > ADJACENT_CONFIRM_MAX_SPEED_DIFF:
-      return False
-
-    if lane_width > 0.0 and abs(adjacent_lead.get('yRel', 0.0)) > lane_width:
-      return False
-
-    return True
-
-  def _adjacent_candidate_passes_vision(self, track_id: int, sm: messaging.SubMaster) -> Tuple[bool, float]:
-    if track_id not in self.tracks:
-      return False, 0.0
-
-    leads_v3 = sm['modelV2'].leadsV3
-    if len(leads_v3) == 0:
-      return False, 0.0
-
-    probability_threshold = self.frogpilot_toggles.lead_detection_probability * ADJACENT_PROBABILITY_MULTIPLIER
-
-    for lead_msg in leads_v3:
-      matched_track = match_vision_to_track(
-        self.v_ego,
-        lead_msg,
-        sm['modelV2'],
-        self.tracks,
-        preferred_track_id=track_id,
-        human_lane_changes_enabled=self.frogpilot_toggles.human_lane_changes,
-      )
-
-      if matched_track is not None and matched_track.identifier == track_id:
-        return lead_msg.prob >= probability_threshold, float(lead_msg.prob)
-
-    return False, 0.0
-
-  def _clear_adjacent_override(self):
-    self.adjacent_override_track_id = None
-    self.adjacent_release_frames = 0
-
-  def _reset_adjacent_tracking(self):
-    self.adjacent_candidate_track_id = None
-    self.adjacent_candidate_frames = 0
-
-  def _update_adjacent_override(self, sm: messaging.SubMaster):
-    if not (self.frogpilot_toggles.human_lane_changes and self.ready):
-      self._reset_adjacent_tracking()
-      self._clear_adjacent_override()
-      self.lane_change_initial_lead_id = None
-      self.prev_lane_change_state = LaneChangeState.off
-      return
-
-    lane_change_state = sm['modelV2'].meta.laneChangeState
-    lane_change_direction = sm['modelV2'].meta.laneChangeDirection
-
-    if lane_change_state == LaneChangeState.laneChangeFinishing:
-      self._reset_adjacent_tracking()
-      self._clear_adjacent_override()
-      self.lane_change_initial_lead_id = None
-      self.prev_lane_change_state = lane_change_state
-      return
-
-    relevant_states = (LaneChangeState.preLaneChange, LaneChangeState.laneChangeStarting)
-
-    if lane_change_state in (LaneChangeState.preLaneChange, LaneChangeState.laneChangeStarting) and \
-       self.prev_lane_change_state not in relevant_states:
-      self.lane_change_initial_lead_id = self.current_lead_track_id
-
-    if lane_change_state not in relevant_states or \
-       lane_change_direction not in (LaneChangeDirection.left, LaneChangeDirection.right):
-      self._reset_adjacent_tracking()
-      self._clear_adjacent_override()
-      if lane_change_state not in relevant_states:
-        self.lane_change_initial_lead_id = None
-      self.prev_lane_change_state = lane_change_state
-      return
-
-    checking_left = lane_change_direction == LaneChangeDirection.left
-    lane_width = sm['frogpilotPlan'].laneWidthLeft if checking_left else sm['frogpilotPlan'].laneWidthRight
-    lane_detected = not self.frogpilot_toggles.lane_detection or lane_width >= self.frogpilot_toggles.lane_detection_width
-
-    if not lane_detected:
-      self._reset_adjacent_tracking()
-      self._clear_adjacent_override()
-      self.prev_lane_change_state = lane_change_state
-      return
-
-    adjacent_lead = get_adjacent_lead(self.tracks, sm['carState'].standstill, sm['modelV2'], left=checking_left)
-
-    candidate_valid = self._valid_adjacent_candidate(adjacent_lead, lane_width)
-    track_id = adjacent_lead.get('radarTrackId') if candidate_valid else None
-
-    if candidate_valid and track_id == self.lane_change_initial_lead_id:
-      candidate_valid = False
-
-    if candidate_valid and track_id is not None:
-      vision_passed, _ = self._adjacent_candidate_passes_vision(track_id, sm)
-      if not vision_passed:
-        candidate_valid = False
-
-    if candidate_valid and track_id is not None:
-      if track_id == self.adjacent_candidate_track_id:
-        self.adjacent_candidate_frames = min(self.adjacent_candidate_frames + 1, ADJACENT_CONFIRM_FRAMES)
-      else:
-        self.adjacent_candidate_track_id = track_id
-        self.adjacent_candidate_frames = 1
-
-      self.adjacent_release_frames = ADJACENT_RELEASE_FRAMES
-
-      if self.adjacent_candidate_frames >= ADJACENT_CONFIRM_FRAMES:
-        self.adjacent_override_track_id = track_id
-
-    if not candidate_valid:
-      self._reset_adjacent_tracking()
-      if self.adjacent_override_track_id is not None:
-        if self.adjacent_release_frames > 0:
-          self.adjacent_release_frames -= 1
-        else:
-          self._clear_adjacent_override()
-
-    self.prev_lane_change_state = lane_change_state
 
   def update(self, sm: messaging.SubMaster, rr):
     self.ready = sm.seen['modelV2']
@@ -535,16 +442,6 @@ class RadarD:
       model_v_ego = self.v_ego
     leads_v3 = sm['modelV2'].leadsV3
 
-    if self.frogpilot_toggles.human_lane_changes:
-      self._update_adjacent_override(sm)
-      preferred_track_id = self.adjacent_override_track_id if self.adjacent_override_track_id in self.tracks else None
-    else:
-      self._reset_adjacent_tracking()
-      self._clear_adjacent_override()
-      self.lane_change_initial_lead_id = None
-      self.prev_lane_change_state = LaneChangeState.off
-      preferred_track_id = None
-
     if len(leads_v3) > 1:
       lead_one = get_lead(
         self.v_ego,
@@ -557,14 +454,11 @@ class RadarD:
         sm['frogpilotPlan'],
         self.frogpilot_toggles,
         low_speed_override=True,
-        preferred_track_id=preferred_track_id,
-        human_lane_changes_enabled=self.frogpilot_toggles.human_lane_changes,
       )
+      self._update_lane_change_surrogates(sm, lead_one)
+
       lead_one = self._apply_overtake_surrogate(lead_one, sm)
       self.radar_state.leadOne = lead_one
-
-      lead_one_track_id = lead_one.get('radarTrackId') if lead_one.get('status', False) else None
-      self.current_lead_track_id = lead_one_track_id if (lead_one_track_id is not None and lead_one_track_id >= 0) else None
 
       self.radar_state.leadTwo = get_lead(
         self.v_ego,
@@ -577,10 +471,9 @@ class RadarD:
         sm['frogpilotPlan'],
         self.frogpilot_toggles,
         low_speed_override=False,
-        human_lane_changes_enabled=self.frogpilot_toggles.human_lane_changes,
       )
     else:
-      self.current_lead_track_id = None
+      self._update_lane_change_surrogates(sm, {'status': False})
 
     if (self.frogpilot_toggles.adjacent_lead_tracking or self.frogpilot_toggles.human_lane_changes) and self.ready:
       self.frogpilot_radar_state.leadLeft = get_adjacent_lead(self.tracks, sm['carState'].standstill, sm['modelV2'], left=True)


### PR DESCRIPTION
## Summary
- remove the adjacent-lane override path when matching radar tracks to model leads
- track lane-change surrogate targets using the initial lead and side-specific bookkeeping instead of adjacent lead promotion
- update the overtaking surrogate application to cover the marked lead and new leads on the appropriate side only

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ededf6293c83288169f6082f233f6c