### PR TITLE
Fix human lane change surrogate activation

### DIFF
--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -490,7 +490,7 @@ class RadarD:
 
       if lead_two.get('status', False):
         same_side = (self._lead_side_sign(lead_two) == self._lead_side_sign(lead_one))
-        if same_side:
+        if same_side and surrogate_applied:
           lead_two, _ = self._apply_overtake_surrogate(lead_two, sm, force=True)
         else:
           lead_two, _ = self._apply_overtake_surrogate(lead_two, sm)


### PR DESCRIPTION
## Summary
- gate forced surrogate application for the secondary lead on human lane changes to only occur when a surrogate was applied to the primary lead
- prevent duplicate accelerated lead visualization when not actively changing lanes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ee2668b8488328b5c8f3fa26c51bbe